### PR TITLE
Make sure `npm build` outputs to dist/

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "target": "ES2020",
     "esModuleInterop": true,
     "baseUrl": "./src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "./dist"
   },
   "include": ["src/*.ts"]
 }


### PR DESCRIPTION
Without this, it outputs in-place like so:
```
	src/LLM.js
	src/gptRequest.js
	src/importFiles.js
	src/index.js
	src/interactive.js
	src/log.ts
	src/saveFiles.js
	src/settings.js
	src/utils.js
	src/version.js
```
and all npm scripts referring to dist/ will fail